### PR TITLE
Fix app hanging on start on new-ui

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,7 +17,7 @@ async function createWindow() {
     autoHideMenuBar: true,
     ...(process.platform === "linux" ? { icon } : {}),
     webPreferences: {
-      preload: join(__dirname, "../preload/index.js"),
+      preload: join(__dirname, "../preload/index.mjs"),
       sandbox: false,
       webSecurity: false,
     },


### PR DESCRIPTION
Fixed by changing the preload script from `index.js` to `index.mjs`